### PR TITLE
Fix PHP include quoting bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,1 +1,1 @@
-<?php include_once(“index.html”); ?>
+<?php include_once("index.html"); ?>


### PR DESCRIPTION
## Summary
- fix incorrect curly quotes in `index.php`

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b943f02883248ed49618ced461e8