### PR TITLE
Add marked.js for AI rendering

### DIFF
--- a/prom-visualizer.html
+++ b/prom-visualizer.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- add marked.js script tag to `prom-visualizer.html` so AI markdown renders correctly

## Testing
- `curl -I https://cdn.jsdelivr.net/npm/marked/marked.min.js | head -n 5` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842002664508324b2be3d206dd39d96