### PR TITLE
Fix minor issues in license-visualizer

### DIFF
--- a/license-visualizer.html
+++ b/license-visualizer.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>License Adoption Visualizer</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
@@ -205,8 +205,6 @@
         }
         h2, h3 {
             margin-top: 0;
-        }
-            margin-top: 0; 
         }
 
         #licenseList ul {


### PR DESCRIPTION
## Summary
- fix unescaped ampersand in the Google Fonts link
- clean up duplicated CSS rule causing unmatched braces

## Testing
- `tidy -e license-visualizer.html`

------
https://chatgpt.com/codex/tasks/task_e_6846e7a3d0488324a0d5bb6f25bd0f48