### PR TITLE
Fix AI analysis serialization

### DIFF
--- a/license-visualizer.html
+++ b/license-visualizer.html
@@ -613,12 +613,15 @@
             hideAIResponse();
 
             try {
+                // Chart.js instances contain circular references and cannot be
+                // serialized to JSON, so remove them before sending data.
+                const sanitized = licenses.map(({ chartInstance, ...rest }) => rest);
                 const response = await fetch(BACKEND_URL, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify({ licenses })
+                    body: JSON.stringify({ licenses: sanitized })
                 });
 
                 if (!response.ok) {


### PR DESCRIPTION
## Summary
- sanitize license data before sending to the backend

## Testing
- `npm test` *(fails: ENOENT no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed7190788324affee6b79ecd0896