### PR TITLE
Add AI endpoints config and integrate with AIUtils

### DIFF
--- a/js/AIUtils.js
+++ b/js/AIUtils.js
@@ -1,0 +1,20 @@
+window.AIUtils = {
+  async analyzeWithAI(endpoint, payload) {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!response.ok) {
+      let errorMsg = 'Unknown backend error.';
+      try {
+        const errorBody = await response.json();
+        errorMsg = errorBody.error || errorMsg;
+      } catch (e) {
+        errorMsg = response.statusText;
+      }
+      throw new Error(`Backend Error: ${response.status} ${errorMsg}`);
+    }
+    return response.json();
+  }
+};

--- a/js/ai-endpoints.js
+++ b/js/ai-endpoints.js
@@ -1,0 +1,5 @@
+window.AI_ENDPOINTS = {
+  licenseVisualizer: 'https://csm-ai-backend-43c415c64d97.herokuapp.com/analyze-license-adoption',
+  promVisualizer: 'https://csm-ai-backend-43c415c64d97.herokuapp.com/analyze-prom-alerts',
+  releaseUpdateVisualizer: 'https://csm-ai-backend-43c415c64d97.herokuapp.com/analyze-release-update'
+};

--- a/license-visualizer.html
+++ b/license-visualizer.html
@@ -9,6 +9,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Load marked.js so AI analysis output can be rendered as HTML -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/ai-endpoints.js"></script>
+    <script src="js/AIUtils.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -421,7 +423,7 @@
         const generateChartBtn = document.getElementById('generateChartBtn');
         const aiAnalyzeBtn = document.getElementById('aiAnalyzeBtn');
         const aiResponseArea = document.getElementById('aiResponseArea');
-        const BACKEND_URL = 'https://csm-ai-backend-43c415c64d97.herokuapp.com/analyze-license-adoption';
+        const BACKEND_URL = window.AI_ENDPOINTS.licenseVisualizer;
         const licenseList = document.getElementById('licenseList');
         const chartRoot = document.getElementById('chartRoot');
 
@@ -618,26 +620,7 @@
                 // Chart.js instances contain circular references and cannot be
                 // serialized to JSON, so remove them before sending data.
                 const sanitized = licenses.map(({ chartInstance, ...rest }) => rest);
-                const response = await fetch(BACKEND_URL, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ licenses: sanitized })
-                });
-
-                if (!response.ok) {
-                    let errorMsg = 'Unknown backend error.';
-                    try {
-                        const errorBody = await response.json();
-                        errorMsg = errorBody.error || errorMsg;
-                    } catch (e) {
-                        errorMsg = response.statusText;
-                    }
-                    throw new Error(`Backend Error: ${response.status} ${errorMsg}`);
-                }
-
-                const data = await response.json();
+                const data = await AIUtils.analyzeWithAI(BACKEND_URL, { licenses: sanitized });
                 console.log('Response from backend:', data);
 
                 if (data && data.analysis) {

--- a/prom-visualizer.html
+++ b/prom-visualizer.html
@@ -9,6 +9,8 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/ai-endpoints.js"></script>
+    <script src="js/AIUtils.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -334,7 +336,7 @@
             const topMetricsListWidget = document.getElementById('topMetricsListWidget');
             const aiAnalyzeButton = document.getElementById('aiAnalyzeButton');
             const aiResponseArea = document.getElementById('aiResponseArea');
-            const BACKEND_URL = 'https://csm-ai-backend-43c415c64d97.herokuapp.com/analyze-prom-alerts';
+            const BACKEND_URL = window.AI_ENDPOINTS.promVisualizer;
             let alertCountChartInstance = null;
             let totalDurationChartInstance = null;
             let currentAlerts = [];
@@ -386,26 +388,7 @@
                 hideAIResponse();
 
                 try {
-                    const response = await fetch(BACKEND_URL, {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify({ alerts })
-                    });
-
-                    if (!response.ok) {
-                        let errorMsg = 'Unknown backend error.';
-                        try {
-                            const errorBody = await response.json();
-                            errorMsg = errorBody.error || errorMsg;
-                        } catch (e) {
-                            errorMsg = response.statusText;
-                        }
-                        throw new Error(`Backend Error: ${response.status} ${errorMsg}`);
-                    }
-
-                    const data = await response.json();
+                    const data = await AIUtils.analyzeWithAI(BACKEND_URL, { alerts });
                     console.log('Response from backend:', data);
 
                     if (data && data.analysis) {

--- a/release-update-visualizer.html
+++ b/release-update-visualizer.html
@@ -5,7 +5,9 @@
     <title>Salesforce Release Updates Visualizer</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> <style>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/ai-endpoints.js"></script>
+    <script src="js/AIUtils.js"></script> <style>
         body {
             font-family: 'Inter', sans-serif;
             background-color: #f4f7f6; /* Light gray background */
@@ -411,7 +413,7 @@
         const columnCountInput = document.getElementById('columnCount');
         const columnCountValueSpan = document.getElementById('columnCountValue');
 
-        const BACKEND_URL = 'https://csm-ai-backend-43c415c64d97.herokuapp.com/analyze-release-update';
+        const BACKEND_URL = window.AI_ENDPOINTS.releaseUpdateVisualizer;
         let allUpdatesData = [];
 
         function updateGridColumns(count) {
@@ -507,27 +509,7 @@
             hideAIResponse();
 
             try {
-                const response = await fetch(BACKEND_URL, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(updateData)
-                });
-
-                if (!response.ok) {
-                    let errorMsg = 'Errore sconosciuto dal backend.';
-                    try {
-                        const errorBody = await response.json();
-                        errorMsg = errorBody.error || errorMsg;
-                    } catch (e) {
-                        // Non è riuscito a parsare il JSON, usa il testo di stato
-                        errorMsg = response.statusText;
-                    }
-                    throw new Error(`Errore dal Backend: ${response.status} ${errorMsg}`);
-                }
-
-                const data = await response.json();
+                const data = await AIUtils.analyzeWithAI(BACKEND_URL, updateData);
                 console.log('Risposta ricevuta dal backend:', data);
 
                 if (data && data.analysis) {


### PR DESCRIPTION
## Summary
- add `js/ai-endpoints.js` with endpoint map
- add `js/AIUtils.js` for backend requests
- load new scripts in HTML pages
- use `AI_ENDPOINTS` and `AIUtils.analyzeWithAI` in each tool

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a97cc4efc83249b452f3dc6f89ead