### PR TITLE
Refactor AI helpers into shared module

### DIFF
--- a/js/ai-utils.js
+++ b/js/ai-utils.js
@@ -1,0 +1,80 @@
+(function() {
+  // Shared helper methods for the AI analysis features across visualizer pages.
+  // Exposes `AIUtils` global with functions for showing, hiding and requesting
+  // AI responses from the backend service.
+  function showAIResponse(containerId, markdown) {
+    const area = document.getElementById(containerId);
+    if (!area) return;
+    const content = area.querySelector('#aiResponseContent') || area.querySelector('.ai-response-content');
+    if (!content) return;
+    if (window.marked) {
+      content.innerHTML = marked.parse(markdown);
+    } else {
+      content.textContent = markdown;
+      console.warn('marked.js not found. Showing AI response as plain text.');
+    }
+    area.style.display = 'block';
+  }
+
+  function hideAIResponse(containerId) {
+    const area = document.getElementById(containerId);
+    if (!area) return;
+    const content = area.querySelector('#aiResponseContent') || area.querySelector('.ai-response-content');
+    if (content) content.innerHTML = '';
+    area.style.display = 'none';
+  }
+
+  async function analyzeWithAI({endpoint, payload, buttonId, responseContainerId}) {
+    const button = typeof buttonId === 'string' ? document.getElementById(buttonId) : buttonId;
+    if (!button) return;
+
+    button.textContent = 'Analyzing...';
+    button.disabled = true;
+    button.style.backgroundColor = '#a78bfa';
+    button.style.cursor = 'not-allowed';
+    const spinner = document.createElement('span');
+    spinner.classList.add('loading-indicator');
+    button.appendChild(spinner);
+
+    hideAIResponse(responseContainerId);
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        let errorMsg = 'Unknown backend error.';
+        try {
+          const errorBody = await response.json();
+          errorMsg = errorBody.error || errorMsg;
+        } catch (e) {
+          errorMsg = response.statusText;
+        }
+        throw new Error(`Backend Error: ${response.status} ${errorMsg}`);
+      }
+
+      const data = await response.json();
+      if (data && data.analysis) {
+        showAIResponse(responseContainerId, data.analysis);
+      } else {
+        showAIResponse(responseContainerId, 'Invalid or empty AI response.');
+      }
+
+    } catch (error) {
+      console.error('Error during backend call:', error);
+      showAIResponse(responseContainerId, `AI analysis error: ${error.message || 'Network or backend issue.'}`);
+    } finally {
+      button.textContent = 'Analyze with AI';
+      button.disabled = false;
+      button.style.backgroundColor = '#10b981';
+      button.style.cursor = 'pointer';
+      const existing = button.querySelector('.loading-indicator');
+      if (existing) existing.remove();
+    }
+  }
+
+  window.AIUtils = { showAIResponse, hideAIResponse, analyzeWithAI };
+})();

--- a/license-visualizer.html
+++ b/license-visualizer.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Load marked.js so AI analysis output can be rendered as HTML -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/ai-utils.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -577,89 +578,20 @@
             renderCharts();
         };
 
-        aiAnalyzeBtn.addEventListener('click', () => analyzeWithGemini(licensesData, aiAnalyzeBtn));
-
-        function showAIResponse(response) {
-            if (!aiResponseArea) return;
-            const content = document.getElementById('aiResponseContent');
-            if (window.marked) {
-                content.innerHTML = marked.parse(response);
-            } else {
-                content.textContent = response;
-                console.warn('marked.js not found. Showing AI response as plain text.');
-            }
-            aiResponseArea.style.display = 'block';
-        }
-
-        function hideAIResponse() {
-            if (!aiResponseArea) return;
-            const content = document.getElementById('aiResponseContent');
-            aiResponseArea.style.display = 'none';
-            content.innerHTML = '';
-        }
-
-        async function analyzeWithGemini(licenses, buttonElement) {
-            if (!licenses || licenses.length === 0) {
-                showAIResponse('No license data to analyze.');
+        aiAnalyzeBtn.addEventListener('click', () => {
+            if (!licensesData || licensesData.length === 0) {
+                AIUtils.showAIResponse("aiResponseArea", "No license data to analyze.");
                 return;
             }
+            const sanitized = licensesData.map(({ chartInstance, ...rest }) => rest);
+            AIUtils.analyzeWithAI({
+                endpoint: BACKEND_URL,
+                payload: { licenses: sanitized },
+                buttonId: "aiAnalyzeBtn",
+                responseContainerId: "aiResponseArea"
+            });
+        });
 
-            buttonElement.textContent = 'Analyzing...';
-            buttonElement.disabled = true;
-            buttonElement.style.backgroundColor = '#a78bfa';
-            buttonElement.style.cursor = 'not-allowed';
-            const loadingSpinner = document.createElement('span');
-            loadingSpinner.classList.add('loading-indicator');
-            buttonElement.appendChild(loadingSpinner);
-
-            hideAIResponse();
-
-            try {
-                // Chart.js instances contain circular references and cannot be
-                // serialized to JSON, so remove them before sending data.
-                const sanitized = licenses.map(({ chartInstance, ...rest }) => rest);
-                const response = await fetch(BACKEND_URL, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ licenses: sanitized })
-                });
-
-                if (!response.ok) {
-                    let errorMsg = 'Unknown backend error.';
-                    try {
-                        const errorBody = await response.json();
-                        errorMsg = errorBody.error || errorMsg;
-                    } catch (e) {
-                        errorMsg = response.statusText;
-                    }
-                    throw new Error(`Backend Error: ${response.status} ${errorMsg}`);
-                }
-
-                const data = await response.json();
-                console.log('Response from backend:', data);
-
-                if (data && data.analysis) {
-                    showAIResponse(data.analysis);
-                } else {
-                    showAIResponse('Invalid or empty AI response.');
-                }
-
-            } catch (error) {
-                console.error('Error during backend call:', error);
-                showAIResponse(`AI analysis error: ${error.message || 'Network or backend issue.'}`);
-            } finally {
-                buttonElement.textContent = 'Analyze with AI';
-                buttonElement.disabled = false;
-                buttonElement.style.backgroundColor = '#10b981';
-                buttonElement.style.cursor = 'pointer';
-                const spinner = buttonElement.querySelector('.loading-indicator');
-                if (spinner) {
-                    spinner.remove();
-                }
-            }
-        }
 
         generateChartBtn.addEventListener('click', renderCharts);
         function renderCharts() {

--- a/prom-visualizer.html
+++ b/prom-visualizer.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ProM Alert Visualizer</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/prom-visualizer.html
+++ b/prom-visualizer.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/ai-utils.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -340,7 +341,18 @@
             let currentAlerts = [];
 
             visualizeButton.addEventListener('click', visualizeData);
-            aiAnalyzeButton.addEventListener('click', () => analyzeWithGemini(currentAlerts, aiAnalyzeButton));
+              aiAnalyzeButton.addEventListener("click", () => {
+                if (!currentAlerts || currentAlerts.length === 0) {
+                    AIUtils.showAIResponse("aiResponseArea", "No alert data to analyze.");
+                    return;
+                }
+                AIUtils.analyzeWithAI({
+                    endpoint: BACKEND_URL,
+                    payload: { alerts: currentAlerts },
+                    buttonId: "aiAnalyzeButton",
+                    responseContainerId: "aiResponseArea"
+                });
+              });
 
             function showMessage(message, type = 'error') {
                 messageBox.textContent = message;
@@ -350,84 +362,6 @@
             }
             function hideMessage() { messageBox.style.display = 'none'; }
 
-            function showAIResponse(response) {
-                if (!aiResponseArea) return;
-                const content = document.getElementById('aiResponseContent');
-                if (window.marked) {
-                    content.innerHTML = marked.parse(response);
-                } else {
-                    content.textContent = response;
-                    console.warn('marked.js not found. Showing AI response as plain text.');
-                }
-                aiResponseArea.style.display = 'block';
-            }
-
-            function hideAIResponse() {
-                if (!aiResponseArea) return;
-                const content = document.getElementById('aiResponseContent');
-                aiResponseArea.style.display = 'none';
-                content.innerHTML = '';
-            }
-
-            async function analyzeWithGemini(alerts, buttonElement) {
-                if (!alerts || alerts.length === 0) {
-                    showAIResponse('No alert data to analyze.');
-                    return;
-                }
-
-                buttonElement.textContent = 'Analyzing...';
-                buttonElement.disabled = true;
-                buttonElement.style.backgroundColor = '#a78bfa';
-                buttonElement.style.cursor = 'not-allowed';
-                const loadingSpinner = document.createElement('span');
-                loadingSpinner.classList.add('loading-indicator');
-                buttonElement.appendChild(loadingSpinner);
-
-                hideAIResponse();
-
-                try {
-                    const response = await fetch(BACKEND_URL, {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify({ alerts })
-                    });
-
-                    if (!response.ok) {
-                        let errorMsg = 'Unknown backend error.';
-                        try {
-                            const errorBody = await response.json();
-                            errorMsg = errorBody.error || errorMsg;
-                        } catch (e) {
-                            errorMsg = response.statusText;
-                        }
-                        throw new Error(`Backend Error: ${response.status} ${errorMsg}`);
-                    }
-
-                    const data = await response.json();
-                    console.log('Response from backend:', data);
-
-                    if (data && data.analysis) {
-                        showAIResponse(data.analysis);
-                    } else {
-                        showAIResponse('Invalid or empty AI response.');
-                    }
-
-                } catch (error) {
-                    console.error('Error during backend call:', error);
-                    showAIResponse(`AI analysis error: ${error.message || 'Network or backend issue.'}`);
-                } finally {
-                    buttonElement.textContent = 'Analyze with AI';
-                    buttonElement.disabled = false;
-                    buttonElement.style.backgroundColor = '#10b981';
-                    buttonElement.style.cursor = 'pointer';
-                    const spinner = buttonElement.querySelector('.loading-indicator');
-                    if (spinner) {
-                        spinner.remove();
-                    }
-                }
-            }
 
             function parseNewRawData(rawText) {
                 console.log("Starting Proactive Monitoring Internal Portal data parsing...");
@@ -531,7 +465,7 @@
 
             function visualizeData() {
                 hideMessage();
-                hideAIResponse();
+                AIUtils.hideAIResponse("aiResponseArea");
                 if (alertCountChartInstance) { alertCountChartInstance.destroy(); alertCountChartInstance = null; }
                 if (totalDurationChartInstance) { totalDurationChartInstance.destroy(); totalDurationChartInstance = null; }
                 totalAlertCountWidget.textContent = '0'; levelBreakdownWidget.innerHTML = ''; topMetricsListWidget.innerHTML = '';

--- a/release-update-visualizer.html
+++ b/release-update-visualizer.html
@@ -5,7 +5,9 @@
     <title>Salesforce Release Updates Visualizer</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> <style>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="js/ai-utils.js"></script>
+    <style>
         body {
             font-family: 'Inter', sans-serif;
             background-color: #f4f7f6; /* Light gray background */
@@ -372,33 +374,6 @@
 
     <script>
         // Funzione per mostrare l'area della risposta AI
-        function showAIResponse(response) {
-            const aiResponseArea = document.getElementById('aiResponseArea');
-            const aiResponseContent = document.getElementById('aiResponseContent');
-
-            // Usa marked.js per convertire Markdown in HTML
-            // NOTA DI SICUREZZA: Se 'response' proviene da una fonte non fidata e può contenere HTML/script malevoli,
-            // dovresti sanitizzare l'output di marked.parse() usando una libreria come DOMPurify.
-            // Esempio: const sanitizedHtml = DOMPurify.sanitize(marked.parse(response));
-            // aiResponseContent.innerHTML = sanitizedHtml;
-            // Per questo esempio, assumiamo che il Markdown dell'AI sia "safe".
-            if (window.marked) {
-                aiResponseContent.innerHTML = marked.parse(response);
-            } else {
-                // Fallback a conversione semplice se marked.js non è caricato
-                aiResponseContent.textContent = response; // Mostra come testo semplice per sicurezza
-                console.warn("Libreria marked.js non trovata. Mostrando risposta AI come testo semplice.");
-            }
-            aiResponseArea.style.display = 'block';
-        }
-
-        // Funzione per nascondere l'area della risposta AI
-        function hideAIResponse() {
-            const aiResponseArea = document.getElementById('aiResponseArea');
-            const aiResponseContent = document.getElementById('aiResponseContent');
-            aiResponseArea.style.display = 'none';
-            aiResponseContent.innerHTML = ''; // Pulisci contenuto quando nascosto
-        }
 
 
         const fileInput = document.getElementById('csvFile');
@@ -440,7 +415,7 @@
             errorMessageDiv.textContent = '';
             updatesContainer.innerHTML = '';
             searchInput.value = '';
-            hideAIResponse();
+            AIUtils.hideAIResponse("aiResponseArea");
 
             const reader = new FileReader();
 
@@ -495,61 +470,6 @@
         });
 
 
-        async function analyzeWithGemini(updateData, buttonElement) {
-            buttonElement.textContent = 'Analisi in corso...';
-            buttonElement.disabled = true;
-            buttonElement.style.backgroundColor = '#a78bfa';
-            buttonElement.style.cursor = 'not-allowed';
-            const loadingSpinner = document.createElement('span');
-            loadingSpinner.classList.add('loading-indicator');
-            buttonElement.appendChild(loadingSpinner);
-
-            hideAIResponse();
-
-            try {
-                const response = await fetch(BACKEND_URL, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(updateData)
-                });
-
-                if (!response.ok) {
-                    let errorMsg = 'Errore sconosciuto dal backend.';
-                    try {
-                        const errorBody = await response.json();
-                        errorMsg = errorBody.error || errorMsg;
-                    } catch (e) {
-                        // Non è riuscito a parsare il JSON, usa il testo di stato
-                        errorMsg = response.statusText;
-                    }
-                    throw new Error(`Errore dal Backend: ${response.status} ${errorMsg}`);
-                }
-
-                const data = await response.json();
-                console.log('Risposta ricevuta dal backend:', data);
-
-                if (data && data.analysis) {
-                    showAIResponse(data.analysis);
-                } else {
-                    showAIResponse("Risposta AI non valida o vuota.");
-                }
-
-            } catch (error) {
-                console.error("Errore durante la chiamata al backend:", error);
-                showAIResponse(`Errore durante l'analisi AI: ${error.message || 'Si è verificato un problema di rete o del backend.'}`);
-            } finally {
-                buttonElement.textContent = 'Analizza con AI';
-                buttonElement.disabled = false;
-                buttonElement.style.backgroundColor = '#10b981';
-                buttonElement.style.cursor = 'pointer';
-                const spinner = buttonElement.querySelector('.loading-indicator');
-                if (spinner) {
-                    spinner.remove();
-                }
-            }
-        }
 
 
         function parseCSV(text) {
@@ -647,14 +567,14 @@
 
         function displayUpdates(data) {
             updatesContainer.innerHTML = '';
-            hideAIResponse();
+            AIUtils.hideAIResponse("aiResponseArea");
 
             if (data.length === 0) {
                 updatesContainer.innerHTML = '<p class="text-center text-gray-600 col-span-full">Nessun aggiornamento della release trovato per i criteri specificati.</p>';
                 return;
             }
 
-            data.forEach(update => {
+            data.forEach((update, index) => {
                 const card = document.createElement('div');
                 const statusClass = update.Status ? update.Status.toLowerCase().replace(/\s+/g, '').replace(/[^\w-]/g, '') : 'sconosciuto';
                 card.classList.add('card', `status-${statusClass}`, 'flex', 'flex-col');
@@ -679,9 +599,16 @@
                 `;
                 updatesContainer.appendChild(card);
 
-                const analyzeButton = card.querySelector('.analyze-btn');
-                analyzeButton.addEventListener('click', () => {
-                    analyzeWithGemini(update, analyzeButton);
+                const analyzeButton = card.querySelector(".analyze-btn");
+                const analyzeId = `analyze-${index}`;
+                analyzeButton.id = analyzeId;
+                analyzeButton.addEventListener("click", () => {
+                    AIUtils.analyzeWithAI({
+                        endpoint: BACKEND_URL,
+                        payload: update,
+                        buttonId: analyzeId,
+                        responseContainerId: "aiResponseArea"
+                    });
                 });
             });
             updateGridColumns(columnCountInput.value);

--- a/release-update-visualizer.html
+++ b/release-update-visualizer.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Salesforce Release Updates Visualizer</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/ai-utils.js"></script>
     <style>


### PR DESCRIPTION
## Summary
- centralize AI helper functions in `js/ai-utils.js`
- include the helper module in all visualizer pages
- switch event handlers to use `AIUtils.analyzeWithAI`
- add header comments to new helper file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a9788810083249ad2725900e6b12d