### PR TITLE
Update HTML to load endpoints config

### DIFF
--- a/license-visualizer.html
+++ b/license-visualizer.html
@@ -11,6 +11,7 @@
     <!-- Load marked.js so AI analysis output can be rendered as HTML -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/ai-utils.js"></script>
+    <script src="js/ai-endpoints.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;

--- a/prom-visualizer.html
+++ b/prom-visualizer.html
@@ -10,6 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/ai-utils.js"></script>
+    <script src="js/ai-endpoints.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;

--- a/release-update-visualizer.html
+++ b/release-update-visualizer.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/ai-utils.js"></script>
+    <script src="js/ai-endpoints.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- load `js/ai-endpoints.js` after other external scripts in the three visualizer HTML pages so AI_ENDPOINTS is defined before page scripts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ab3f04c848324bbf25f139cc67624