### PR TITLE
Fix radio button layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -254,9 +254,10 @@ canvas {
     margin-bottom: 0.5rem;
 }
 .source-selector-options label {
+    display: inline-block;
+    margin: 0 0 0 0.25rem;
     color: #4b5563;
     cursor: pointer;
-    margin-left: 0.25rem;
 }
 .source-selector-options input[type="radio"] {
     accent-color: #4f46e5;

--- a/prom-visualizer.html
+++ b/prom-visualizer.html
@@ -11,6 +11,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/ai-utils.js"></script>
     <script src="js/ai-endpoints.js"></script>
+    <link rel="stylesheet" href="css/ai-utils.css">
     <link rel="stylesheet" href="css/main.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- tweak `.source-selector-options label` style so radios align to the left of labels

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685140337b708324b481a9c9e3bb11cb