### PR TITLE
Improve MC Report extractor URL matching and button retry

### DIFF
--- a/tampermonkey/ProM MC Report - Alerts extractor.js
+++ b/tampermonkey/ProM MC Report - Alerts extractor.js
@@ -4,7 +4,7 @@
 // @version      1.0
 // @description  Extracts table data from a Salesforce Lightning report, downloads CSV, copies TSV to the clipboard, and opens the helper tool.
 // @author       Saverio Guardato
-// @match        https://orgcs.lightning.force.com/lightning/r/Report/00OHx000001AmPNMA0/view?queryScope=userFolders
+// @match        https://orgcs.lightning.force.com/lightning/r/Report/00OHx000001AmPNMA0*
 // @grant        GM_addStyle
 // @grant        GM_setClipboard
 // @run-at       document-end
@@ -144,11 +144,18 @@
         }
     }
 
-    const observer = new MutationObserver((mutations, obs) => {
+    const startTime = Date.now();
+    const intervalId = setInterval(() => {
+        if (document.getElementById(BUTTON_ID)) {
+            clearInterval(intervalId);
+            return;
+        }
         if (document.querySelector('table.data-grid-table.data-grid-full-table')) {
             addButton();
-            obs.disconnect();
+            clearInterval(intervalId);
+        } else if (Date.now() - startTime >= 60000) {
+            clearInterval(intervalId);
+            console.warn('Timeout waiting for report table');
         }
-    });
-    observer.observe(document, { childList: true, subtree: true });
+    }, 500);
 })();


### PR DESCRIPTION
## Summary
- widen the Tampermonkey `@match` for ProM MC Report extractor
- retry button injection every 500ms for up to 60s

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598c932d0c83248a131ae7e5317898