### PR TITLE
Delay MC report extractor start after page load

### DIFF
--- a/tampermonkey/ProM MC Report - Alerts extractor.js
+++ b/tampermonkey/ProM MC Report - Alerts extractor.js
@@ -144,18 +144,24 @@
         }
     }
 
-    const startTime = Date.now();
-    const intervalId = setInterval(() => {
-        if (document.getElementById(BUTTON_ID)) {
-            clearInterval(intervalId);
-            return;
-        }
-        if (document.querySelector('table.data-grid-table.data-grid-full-table')) {
-            addButton();
-            clearInterval(intervalId);
-        } else if (Date.now() - startTime >= 60000) {
-            clearInterval(intervalId);
-            console.warn('Timeout waiting for report table');
-        }
-    }, 500);
+    function start() {
+        const startTime = Date.now();
+        const intervalId = setInterval(() => {
+            if (document.getElementById(BUTTON_ID)) {
+                clearInterval(intervalId);
+                return;
+            }
+            if (document.querySelector('table.data-grid-table.data-grid-full-table')) {
+                addButton();
+                clearInterval(intervalId);
+            } else if (Date.now() - startTime >= 60000) {
+                clearInterval(intervalId);
+                console.warn('Timeout waiting for report table');
+            }
+        }, 500);
+    }
+
+    window.addEventListener('load', () => {
+        setTimeout(start, 5000);
+    });
 })();


### PR DESCRIPTION
## Summary
- ensure actions run 5 seconds after page load in `ProM MC Report - Alerts extractor.js`

## Testing
- `git diff --color`

------
https://chatgpt.com/codex/tasks/task_e_685a9d18a9fc83249baf4cf95ac3a3cf